### PR TITLE
Add counters per topic

### DIFF
--- a/fm-metrics/count.py
+++ b/fm-metrics/count.py
@@ -1,42 +1,75 @@
+from fedora_messaging.message import Message
 from prometheus_client import Counter
+import logging
+
+logger = logging.getLogger(__name__)
 
 
-class Message:
+COUNTERS_DATA = [
+    {
+        'topic': 'org.fedoraproject.prod.buildsys.tag',
+        'name': 'fedora_tag',
+        'description': "Count Fedora tag messages",
+        'labels': ['tag'],
+     },
+    {
+        'topic': 'org.centos.prod.buildsys.tag',
+        'name': 'centos_tag',
+        'description': "Count CentOS tag messages",
+        'labels': ['tag'],
+    },
+    {
+        'topic': 'DEFAULT',
+        'name': 'simple',
+        'description': "Count all messages",
+        'labels': ['topic'],
+    },
+]
 
-    LABELS = [
-        'topic',
-        'testcase',
-        'status',
-        'result',
-    ]
-    
-    def __init__(self, message):
-        self.topic = message.topic
-        
-        if "test" in message.body:
-            self.testcase = ".".join([
-                message.body["test"]["namespace"],
-                message.body["test"]["category"],
-                message.body["test"]["type"],
-            ])
-            self.result = message.body["test"].get("result", "undefined")
+
+class CounterRegistry:
+
+    def __init__(self, counters_data=[]):
+        self.counters={}
+
+        for counter_data in counters_data:
+            self.add_counter(**counter_data)
+
+    def add_counter(self, name, description, topic, labels):
+        if topic in self.counters:
+            logger.warning("Counter for {topic} already exists")
+            return self.counters[topic]
+
+        counter = Counter(
+            name,
+            description,
+            labels,
+        )
+
+        self.counters[topic] = counter
+        return counter
+
+    def get_counter(self, topic):
+        if topic in self.counters:
+            return self.counters[topic]
         else:
-            self.testcase = "undefined"
-            self.result = "undefined"
+            return self.counters['DEFAULT']
 
-        self.status = message.topic.split(".")[-1]
-            
-    def labels(self):
-        return { label: self.__getattribute__(label) for label in self.LABELS}
+CR = CounterRegistry(COUNTERS_DATA)
 
 
-MessageCounter = Counter(
-    'messages',
-    'Count messages',
-    Message.LABELS,
-)
+def get_labels(message, labels):
+    result = {}
+    for label in labels:
+        result[label] = getattr(message,
+                                label,
+                                message.body.get(label,
+                                                 message._headers.get(label, "")
+                                                 )
+                                )
+    return result
 
 def count_message(message):
-    m = Message(message)
-    MessageCounter.labels(**m.labels()).inc()
-
+    message_counter = CR.get_counter(message.topic)
+    message_labels = get_labels(message, message_counter._labelnames)
+    message_counter.labels(**message_labels).inc()


### PR DESCRIPTION
Labelling and counting messages depends on the topic.

For Koji tag messages we are interested in the tag field, for generic test message we can start with topic.